### PR TITLE
Add macOS bundle packaging and CI build

### DIFF
--- a/.github/workflows/macos-app.yml
+++ b/.github/workflows/macos-app.yml
@@ -1,0 +1,22 @@
+name: macOS App Bundle
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Build macOS app bundle
+        run: packaging/macos/build_app.sh
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Pathway-macos
+          path: packaging/macos/dist/*.zip
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ Desktop.ini
 # Binary releases
 /dist/
 /releases/
+packaging/macos/build/
+packaging/macos/dist/

--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>PathwayShim</string>
+    <key>CFBundleIdentifier</key>
+    <string>dev.pathway.router</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Pathway</string>
+    <key>CFBundleDisplayName</key>
+    <string>Pathway Browser Router</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>@VERSION@</string>
+    <key>CFBundleVersion</key>
+    <string>@VERSION@</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>10.15</string>
+    <key>LSBackgroundOnly</key>
+    <true/>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>Web URL</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>http</string>
+                <string>https</string>
+            </array>
+        </dict>
+    </array>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>Pathway needs to control browsers to open URLs.</string>
+    <key>CFBundleIconFile</key>
+    <string>icon</string>
+</dict>
+</plist>

--- a/packaging/macos/PathwayShim.entitlements
+++ b/packaging/macos/PathwayShim.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+</dict>
+</plist>

--- a/packaging/macos/PathwayShim.swift
+++ b/packaging/macos/PathwayShim.swift
@@ -1,0 +1,129 @@
+import Cocoa
+import os.log
+
+private let subsystem = "dev.pathway.router"
+
+final class PathwayAppDelegate: NSObject, NSApplicationDelegate {
+    private let logger = Logger(subsystem: subsystem, category: "shim")
+    private let eventManager = NSAppleEventManager.shared()
+    private let syncQueue = DispatchQueue(label: "dev.pathway.router.shim.queue")
+    private var pendingLaunches = 0
+    private var activeProcesses: [Process] = []
+    private var terminationWorkItem: DispatchWorkItem?
+    private let terminationDelay: TimeInterval = 1.0
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        eventManager.setEventHandler(self,
+                                     andSelector: #selector(handleGetURLEvent(event:replyEvent:)),
+                                     forEventClass: AEEventClass(kInternetEventClass),
+                                     andEventID: AEEventID(kAEGetURL))
+        scheduleTerminationCheck()
+    }
+
+    func application(_ application: NSApplication, open urls: [URL]) {
+        handle(urls: urls)
+    }
+
+    @objc private func handleGetURLEvent(event: NSAppleEventDescriptor, replyEvent: NSAppleEventDescriptor) {
+        var urls: [URL] = []
+        if let directObject = event.paramDescriptor(forKeyword: keyDirectObject) {
+            if directObject.descriptorType == typeAEList {
+                for index in 1...directObject.numberOfItems {
+                    if let value = directObject.atIndex(index)?.stringValue, let url = URL(string: value) {
+                        urls.append(url)
+                    }
+                }
+            } else if let value = directObject.stringValue, let url = URL(string: value) {
+                urls.append(url)
+            }
+        }
+        handle(urls: urls)
+    }
+
+    private func handle(urls: [URL]) {
+        syncQueue.async { [weak self] in
+            guard let self = self else { return }
+            guard !urls.isEmpty else {
+                self.logger.debug("Received empty URL payload")
+                self.scheduleTerminationCheckLocked()
+                return
+            }
+
+            guard let pathwayURL = Bundle.main.url(forResource: "pathway", withExtension: nil) else {
+                self.logger.fault("Unable to locate bundled pathway binary")
+                self.scheduleTerminationCheckLocked()
+                return
+            }
+
+            self.pendingLaunches += 1
+            let process = Process()
+            process.executableURL = pathwayURL
+            process.arguments = urls.map { $0.absoluteString }
+            self.activeProcesses.append(process)
+
+            var environment = ProcessInfo.processInfo.environment
+            environment["PATHWAY_LAUNCHED_FROM_BUNDLE"] = "1"
+            if let identifier = Bundle.main.bundleIdentifier {
+                environment["PATHWAY_BUNDLE_IDENTIFIER"] = identifier
+            }
+            process.environment = environment
+
+            process.standardInput = FileHandle.nullDevice
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+
+            process.terminationHandler = { [weak self] _ in
+                guard let self = self else { return }
+                self.syncQueue.async {
+                    self.activeProcesses.removeAll { $0 === process }
+                    self.pendingLaunches = max(0, self.pendingLaunches - 1)
+                    self.scheduleTerminationCheckLocked()
+                }
+            }
+
+            do {
+                try process.run()
+                self.logger.info("Forwarded \(urls.count) URL(s) to pathway binary")
+            } catch {
+                self.logger.error("Failed to launch pathway binary: \(error.localizedDescription)")
+                self.activeProcesses.removeAll { $0 === process }
+                self.pendingLaunches = max(0, self.pendingLaunches - 1)
+                self.scheduleTerminationCheckLocked()
+            }
+        }
+    }
+
+    private func scheduleTerminationCheck() {
+        syncQueue.async { [weak self] in
+            self?.scheduleTerminationCheckLocked()
+        }
+    }
+
+    private func scheduleTerminationCheckLocked() {
+        terminationWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self = self else { return }
+            self.syncQueue.async {
+                if self.pendingLaunches == 0 {
+                    self.logger.debug("No pending launches, terminating shim")
+                    DispatchQueue.main.async {
+                        NSApp.terminate(nil)
+                    }
+                }
+            }
+        }
+        terminationWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + terminationDelay, execute: workItem)
+    }
+}
+
+@main
+final class PathwayShim {
+    static func main() {
+        let application = NSApplication.shared
+        application.setActivationPolicy(.prohibited)
+        let delegate = PathwayAppDelegate()
+        application.delegate = delegate
+        application.run()
+    }
+}

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -1,0 +1,20 @@
+# Pathway macOS Bundle
+
+This directory contains the resources required to build the `Pathway.app` bundle.
+
+## Contents
+
+- `build_app.sh` &ndash; orchestrates compiling the universal Rust binary and Swift shim, assembles the bundle, signs it, and produces a distributable archive.
+- `Info.plist` &ndash; template used to generate the bundle metadata.
+- `PathwayShim.swift` &ndash; background-only Cocoa application that forwards URL events to the bundled `pathway` binary.
+- `PathwayShim.entitlements` &ndash; entitlements used for ad-hoc code signing.
+
+## Building locally
+
+Run the build script on a macOS host with the Xcode command line tools installed:
+
+```bash
+./packaging/macos/build_app.sh
+```
+
+The resulting bundle is written to `packaging/macos/build/Pathway.app` and a ready-to-ship archive is created in `packaging/macos/dist/`.

--- a/packaging/macos/build_app.sh
+++ b/packaging/macos/build_app.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "This script must be run on macOS." >&2
+  exit 1
+fi
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command '$1' not found in PATH" >&2
+    exit 1
+  fi
+}
+
+require_cmd rustup
+require_cmd cargo
+require_cmd xcrun
+require_cmd swiftc
+require_cmd lipo
+require_cmd codesign
+require_cmd ditto
+require_cmd plutil
+require_cmd python3
+require_cmd sips
+require_cmd iconutil
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CORE_DIR="$ROOT_DIR/core"
+PKG_DIR="$ROOT_DIR/packaging/macos"
+BUILD_DIR="$PKG_DIR/build"
+DIST_DIR="$PKG_DIR/dist"
+APP_NAME="Pathway"
+APP_BUNDLE="$BUILD_DIR/${APP_NAME}.app"
+INFO_TEMPLATE="$PKG_DIR/Info.plist"
+ENTITLEMENTS_FILE="$PKG_DIR/PathwayShim.entitlements"
+SWIFT_SRC="$PKG_DIR/PathwayShim.swift"
+ICON_SRC="$ROOT_DIR/assets/pathway-logo.png"
+SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
+
+mkdir -p "$BUILD_DIR" "$DIST_DIR"
+rm -rf "$APP_BUNDLE"
+mkdir -p "$APP_BUNDLE/Contents/MacOS" "$APP_BUNDLE/Contents/Resources"
+
+VERSION=$(cd "$ROOT_DIR" && python3 - <<'PY'
+import pathlib
+import re
+
+toml_text = pathlib.Path("core/Cargo.toml").read_text()
+match = re.search(r'^version\s*=\s*"([^"]+)"', toml_text, re.MULTILINE)
+print(match.group(1) if match else "0.0.0")
+PY
+)
+
+rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+pushd "$CORE_DIR" >/dev/null
+cargo build --release --target aarch64-apple-darwin
+cargo build --release --target x86_64-apple-darwin
+popd >/dev/null
+
+lipo -create \
+  "$CORE_DIR/target/aarch64-apple-darwin/release/pathway" \
+  "$CORE_DIR/target/x86_64-apple-darwin/release/pathway" \
+  -output "$APP_BUNDLE/Contents/Resources/pathway"
+chmod +x "$APP_BUNDLE/Contents/Resources/pathway"
+
+SWIFT_ARM="$BUILD_DIR/PathwayShim-arm64"
+SWIFT_X86="$BUILD_DIR/PathwayShim-x86_64"
+
+swiftc -O -sdk "$SDK_PATH" -target arm64-apple-macos11 "$SWIFT_SRC" -o "$SWIFT_ARM"
+swiftc -O -sdk "$SDK_PATH" -target x86_64-apple-macos10.15 "$SWIFT_SRC" -o "$SWIFT_X86"
+
+lipo -create "$SWIFT_ARM" "$SWIFT_X86" -output "$APP_BUNDLE/Contents/MacOS/PathwayShim"
+chmod +x "$APP_BUNDLE/Contents/MacOS/PathwayShim"
+rm -f "$SWIFT_ARM" "$SWIFT_X86"
+
+/usr/bin/sed "s/@VERSION@/$VERSION/g" "$INFO_TEMPLATE" > "$APP_BUNDLE/Contents/Info.plist"
+plutil -lint "$APP_BUNDLE/Contents/Info.plist" >/dev/null
+
+if [[ -f "$ICON_SRC" ]]; then
+  ICONSET_DIR="$BUILD_DIR/icon.iconset"
+  rm -rf "$ICONSET_DIR"
+  mkdir -p "$ICONSET_DIR"
+  declare -a SIZES=(16 32 64 128 256 512)
+  for SIZE in "${SIZES[@]}"; do
+    sips -z "$SIZE" "$SIZE" "$ICON_SRC" --out "$ICONSET_DIR/icon_${SIZE}x${SIZE}.png" >/dev/null
+    DOUBLE=$((SIZE * 2))
+    sips -z "$DOUBLE" "$DOUBLE" "$ICON_SRC" --out "$ICONSET_DIR/icon_${SIZE}x${SIZE}@2x.png" >/dev/null
+  done
+  iconutil -c icns "$ICONSET_DIR" -o "$APP_BUNDLE/Contents/Resources/icon.icns"
+fi
+
+if [[ -f "$ENTITLEMENTS_FILE" ]]; then
+  codesign --force --deep --sign - --entitlements "$ENTITLEMENTS_FILE" "$APP_BUNDLE"
+else
+  codesign --force --deep --sign - "$APP_BUNDLE"
+fi
+
+codesign --verify --deep --strict "$APP_BUNDLE"
+
+OUTPUT_ZIP="$DIST_DIR/Pathway-${VERSION}.zip"
+rm -f "$OUTPUT_ZIP"
+ditto -c -k --keepParent "$APP_BUNDLE" "$OUTPUT_ZIP"
+
+echo "Created bundle at $APP_BUNDLE"
+echo "Created archive at $OUTPUT_ZIP"


### PR DESCRIPTION
## Summary
- add macOS packaging resources including Swift shim, Info.plist template, entitlements, and README
- create build script that produces a universal Pathway.app bundle and zip archive
- configure GitHub Actions workflow to build the macOS bundle on each push and pull request

## Testing
- `cargo test` *(fails: existing doctest `src/browser/linux.rs - browser::linux::launch_with_profile` panics in the documentation example)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf02a09c88324ae4d03720e0bc63e